### PR TITLE
Fixing typo in Fixed-Type Arrays in Python section

### DIFF
--- a/notebooks/02.01-Understanding-Data-Types.ipynb
+++ b/notebooks/02.01-Understanding-Data-Types.ipynb
@@ -329,7 +329,7 @@
     "Here ``'i'`` is a type code indicating the contents are integers.\n",
     "\n",
     "Much more useful, however, is the ``ndarray`` object of the NumPy package.\n",
-    "While Python's ``array`` obnject provides efficient storage of array-based data, NumPy adds to this efficient *operations* on that data.\n",
+    "While Python's ``array`` object provides efficient storage of array-based data, NumPy adds to this efficient *operations* on that data.\n",
     "We will explore these operations in later sections; here we'll demonstrate several ways of creating a NumPy array.\n",
     "\n",
     "We'll start with the standard NumPy import, under the alias ``np``:"


### PR DESCRIPTION
Changing one occurrence of "obnject" to "object"