### PR TITLE
correct jupyter notebook package name

### DIFF
--- a/notebooks/00.00-Preface.ipynb
+++ b/notebooks/00.00-Preface.ipynb
@@ -157,7 +157,7 @@
     "To get started, download and install the Miniconda package–make sure to choose a version with Python 3–and then install the core packages used in this book:\n",
     "\n",
     "```\n",
-    "[~]$ conda install numpy pandas scikit-learn matplotlib seaborn ipython-notebook\n",
+    "[~]$ conda install numpy pandas scikit-learn matplotlib seaborn jupyter\n",
     "```\n",
     "\n",
     "Throughout the text, we will also make use of other more specialized tools in Python's scientific ecosystem; installation is usually as easy as typing **``conda install packagename``**.\n",


### PR DESCRIPTION
since ipython notebooks is now called jupyter notebooks they also changed the package names and the easiest thing to do is simply install `jupyter` package which brinks everything you'll need.