### PR TITLE
Fix typo in 02.06-Boolean-Arrays-and-Masks.ipynb

### DIFF
--- a/notebooks/02.06-Boolean-Arrays-and-Masks.ipynb
+++ b/notebooks/02.06-Boolean-Arrays-and-Masks.ipynb
@@ -777,7 +777,7 @@
       "Number days without rain:       215\n",
       "Number days with rain:          150\n",
       "Days with more than 0.5 inches: 37\n",
-      "Rainy days with < 0.1 inches  : 75\n"
+      "Rainy days with < 0.2 inches  : 75\n"
      ]
     }
    ],
@@ -785,7 +785,7 @@
     "print(\"Number days without rain:      \", np.sum(inches == 0))\n",
     "print(\"Number days with rain:         \", np.sum(inches != 0))\n",
     "print(\"Days with more than 0.5 inches:\", np.sum(inches > 0.5))\n",
-    "print(\"Rainy days with < 0.1 inches  :\", np.sum((inches > 0) &\n",
+    "print(\"Rainy days with < 0.2 inches  :\", np.sum((inches > 0) &\n",
     "                                                (inches < 0.2)))"
    ]
   },


### PR DESCRIPTION
In code uses `0.2` inches (https://github.com/jakevdp/PythonDataScienceHandbook/compare/master...namreg:namreg-patch-1?expand=1#diff-250d2ff33d0bd9c210e6511480714339R789), but in comments uses `0.1` inches. 
I suppose it is a typo :)