### PR TITLE
Typo correction.

### DIFF
--- a/notebooks/05.05-Naive-Bayes.ipynb
+++ b/notebooks/05.05-Naive-Bayes.ipynb
@@ -268,7 +268,7 @@
     "Another useful example is multinomial naive Bayes, where the features are assumed to be generated from a simple multinomial distribution.\n",
     "The multinomial distribution describes the probability of observing counts among a number of categories, and thus multinomial naive Bayes is most appropriate for features that represent counts or count rates.\n",
     "\n",
-    "The idea is precisely the same as before, except that instead of modeling the data distribution with the best-fit Gaussian, we model the data distribuiton with a best-fit multinomial distribution."
+    "The idea is precisely the same as before, except that instead of modeling the data distribution with the best-fit Gaussian, we model the data distribution with a best-fit multinomial distribution."
    ]
   },
   {


### PR DESCRIPTION
Fixing a typo error in the Naive Bayes notebook.

"distribuiton" -> "distribution"