### PR TITLE
add missing aggregation function call

### DIFF
--- a/notebooks/03.08-Aggregation-and-Grouping.ipynb
+++ b/notebooks/03.08-Aggregation-and-Grouping.ipynb
@@ -2025,7 +2025,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Of course, this means there's another, more verbose way of accomplishing the ``df.groupby('key')`` from before:"
+    "Of course, this means there's another, more verbose way of accomplishing the ``df.groupby('key').sum()`` from before:"
    ]
   },
   {


### PR DESCRIPTION
I think what you meant here is that `df.groupby(df['key']).sum()` is a more verbose way of accomplishing `df.groupby('key').sum()` and not `df.groupby('key')`.