### PR TITLE
Update 03.01-Introducing-Pandas-Objects.ipynb

### DIFF
--- a/notebooks/03.01-Introducing-Pandas-Objects.ipynb
+++ b/notebooks/03.01-Introducing-Pandas-Objects.ipynb
@@ -1426,7 +1426,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This immutability makes it safer to share indices between multiple ``DataFrame``s and arrays, without the potential for side effects from inadvertent index modification."
+    "This immutability makes it safer to share indices between multiple ``DataFrame`` and ``Series`` objects, without the potential for side effects from inadvertent index modification."
    ]
   },
   {


### PR DESCRIPTION
I think it should be "series" here, not "array", because Numpy array has no index object?