### PR TITLE
typo: Added ':' to heading

### DIFF
--- a/notebooks/03.11-Working-with-Time-Series.ipynb
+++ b/notebooks/03.11-Working-with-Time-Series.ipynb
@@ -574,7 +574,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pandas Time Series Data Structures\n",
+    "## Pandas Time Series: Data Structures\n",
     "\n",
     "This section will introduce the fundamental Pandas data structures for working with time series data:\n",
     "\n",


### PR DESCRIPTION
I added a semicolon to heading match the heading directly above it.