### PR TITLE
typo: Missing second parenthesis and space added

### DIFF
--- a/notebooks/04.11-Settings-and-Stylesheets.ipynb
+++ b/notebooks/04.11-Settings-and-Stylesheets.ipynb
@@ -477,7 +477,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### *Bayesian Methods for Hackers( style\n",
+    "### *Bayesian Methods for Hackers (style)\n",
     "\n",
     "There is a very nice short online book called [*Probabilistic Programming and Bayesian Methods for Hackers*](http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/); it features figures created with Matplotlib, and uses a nice set of rc parameters to create a consistent and visually-appealing style throughout the book.\n",
     "This style is reproduced in the ``bmh`` stylesheet:"


### PR DESCRIPTION
The word "style" was missing a second parenthesis and the opening parenthesis needed a space between it and "Hacker".  I would probably omit the work "style" and its associated parentheses.