### PR TITLE
Typo: added hyphen to match other titles

### DIFF
--- a/notebooks/05.09-Principal-Component-Analysis.ipynb
+++ b/notebooks/05.09-Principal-Component-Analysis.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#  In Depth: Principal Component Analysis"
+    "#  In-Depth: Principal Component Analysis"
    ]
   },
   {


### PR DESCRIPTION
This title did not match the other titles so I looked on Google to find which one needed to be changed.

Google search:
AP Stylebook: for "in-" as a prefix the AP Style mandates as always requiring a hyphen.

A prefix does not take a hyphen when it means "not", as in incapable, inconsiderate, or incompetent.