### PR TITLE
corrected call to metrics.classification()

### DIFF
--- a/notebooks/05.08-Random-Forests.ipynb
+++ b/notebooks/05.08-Random-Forests.ipynb
@@ -658,7 +658,7 @@
    ],
    "source": [
     "from sklearn import metrics\n",
-    "print(metrics.classification_report(ypred, ytest))"
+    "print(metrics.classification_report(ytest, ypred))"
    ]
   },
   {


### PR DESCRIPTION
corrected the order of input arguments (ypred, ytest) to "metrics.classification()"