### PR TITLE
update scikit-image dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.11.1
 pandas==0.18.1
 scipy==0.17.1
 scikit-learn==0.17.1
-scikit-image==0.12.3
+scikit-image==0.13.1
 pillow==3.4.2
 matplotlib==1.5.1
 seaborn==0.7.0


### PR DESCRIPTION
There's a bug that's been introduced with an interaction between python 3.6, numpy, and the version of scikit-image that's pinned here. This should fix that, and AFAICT `skimage` actually isn't used in the notebooks, so this upgrade shouldn't be breaking yeah? 

https://github.com/jakevdp/PythonDataScienceHandbook/search?utf8=%E2%9C%93&q=skimage&type=

would fix https://github.com/jakevdp/PythonDataScienceHandbook/issues/108