### PR TITLE
np.empty creates floats, not integers, by default

### DIFF
--- a/notebooks/02.01-Understanding-Data-Types.ipynb
+++ b/notebooks/02.01-Understanding-Data-Types.ipynb
@@ -728,7 +728,7 @@
     }
    ],
    "source": [
-    "# Create an uninitialized array of three integers\n",
+    "# Create an uninitialized array of three floats\n",
     "# The values will be whatever happens to already exist at that memory location\n",
     "np.empty(3)"
    ]


### PR DESCRIPTION
Maybe it was meant to use a `dtype=int` keyword argument? However, the output of the command looks like an Array of floats as well, so this change might be the simplest.