### PR TITLE
Update 05.02-Introducing-Scikit-Learn.ipynb

### DIFF
--- a/notebooks/05.02-Introducing-Scikit-Learn.ipynb
+++ b/notebooks/05.02-Introducing-Scikit-Learn.ipynb
@@ -1326,7 +1326,7 @@
    "source": [
     "plt.scatter(data_projected[:, 0], data_projected[:, 1], c=digits.target,\n",
     "            edgecolor='none', alpha=0.5,\n",
-    "            cmap=plt.cm.get_cmap('spectral', 10))\n",
+    "            cmap=plt.cm.get_cmap('nipy_spectral', 10))\n",
     "plt.colorbar(label='digit label', ticks=range(10))\n",
     "plt.clim(-0.5, 9.5);"
    ]


### PR DESCRIPTION
'spectral' is not a valid colormap value