### PR TITLE
adding an environment.yml to specify python version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: data-science-handbook
+channels:
+  - conda-forge
+dependencies:
+  - python=3.5
+  - pip:
+    - -r requirements.txt


### PR DESCRIPTION
Hey @jakevdp , I believe that this should get the install working with Binder! It doesn't fix the underlying numpy/skimage/python3.6 trifecta bug, but works around it. AKA, it still won't work if you just `pip install -r requirements.txt` if you are running Python 3.6 (maybe worth mentioning in the readme?). This PR just adds an `environment.yml` file that pins the python version at 3.5. I tested it on my fork and mybinder.org was able to build it just fine!