### PR TITLE
02.07-Fancy-Indexing: 'same result' is not the same

### DIFF
--- a/notebooks/02.07-Fancy-Indexing.ipynb
+++ b/notebooks/02.07-Fancy-Indexing.ipynb
@@ -118,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "array([71, 86, 60])"
+       "array([71, 86, 14])"
       ]
      },
      "execution_count": 3,
@@ -127,7 +127,7 @@
     }
    ],
    "source": [
-    "ind = [3, 7, 4]\n",
+    "ind = [3, 7, 2]\n",
     "x[ind]"
    ]
   },


### PR DESCRIPTION
It says 'to obtain the same result' but the result is different, because the input is different. This PR changes both the input code and the output so that the second result (which uses fancy indexing) obtains the same result as the first.