### PR TITLE
01.06 update available arguments for xmode.

### DIFF
--- a/notebooks/01.06-Errors-and-Debugging.ipynb
+++ b/notebooks/01.06-Errors-and-Debugging.ipynb
@@ -98,7 +98,7 @@
     "By default, this trace includes several lines showing the context of each step that led to the error.\n",
     "Using the ``%xmode`` magic function (short for *Exception mode*), we can change what information is printed.\n",
     "\n",
-    "``%xmode`` takes a single argument, the mode, and there are three possibilities: ``Plain``, ``Context``, and ``Verbose``.\n",
+    "``%xmode`` takes a single argument, the mode, and there are four possibilities: ``Plain``, ``Context``, ``Verbose`` and ``Minimal``.\n",
     "The default is ``Context``, and gives output like that just shown before.\n",
     "``Plain`` is more compact and gives less information:"
    ]


### PR DESCRIPTION
`%mode`: Current Valid modes: Plain, Context, Verbose, and Minimal.