### PR TITLE
Change plt.hist deprecated normed paramter to density

### DIFF
--- a/notebooks/04.05-Histograms-and-Binnings.ipynb
+++ b/notebooks/04.05-Histograms-and-Binnings.ipynb
@@ -102,7 +102,7 @@
     }
    ],
    "source": [
-    "plt.hist(data, bins=30, normed=True, alpha=0.5,\n",
+    "plt.hist(data, bins=30, density=True, alpha=0.5,\n",
     "         histtype='stepfilled', color='steelblue',\n",
     "         edgecolor='none');"
    ]
@@ -138,7 +138,7 @@
     "x2 = np.random.normal(-2, 1, 1000)\n",
     "x3 = np.random.normal(3, 2, 1000)\n",
     "\n",
-    "kwargs = dict(histtype='stepfilled', alpha=0.3, normed=True, bins=40)\n",
+    "kwargs = dict(histtype='stepfilled', alpha=0.3, density=True, bins=40)\n",
     "\n",
     "plt.hist(x1, **kwargs)\n",
     "plt.hist(x2, **kwargs)\n",

--- a/notebooks/04.14-Visualization-With-Seaborn.ipynb
+++ b/notebooks/04.14-Visualization-With-Seaborn.ipynb
@@ -230,7 +230,7 @@
     "data = pd.DataFrame(data, columns=['x', 'y'])\n",
     "\n",
     "for col in 'xy':\n",
-    "    plt.hist(data[col], normed=True, alpha=0.5)"
+    "    plt.hist(data[col], density=True, alpha=0.5)"
    ]
   },
   {

--- a/notebooks/05.13-Kernel-Density-Estimation.ipynb
+++ b/notebooks/05.13-Kernel-Density-Estimation.ipynb
@@ -111,7 +111,7 @@
    },
    "source": [
     "We have previously seen that the standard count-based histogram can be created with the ``plt.hist()`` function.\n",
-    "By specifying the ``normed`` parameter of the histogram, we end up with a normalized histogram where the height of the bins does not reflect counts, but instead reflects probability density:"
+    "By specifying the ``density`` parameter of the histogram, we end up with a normalized histogram where the height of the bins does not reflect counts, but instead reflects probability density:"
    ]
   },
   {
@@ -135,7 +135,7 @@
     }
    ],
    "source": [
-    "hist = plt.hist(x, bins=30, normed=True)"
+    "hist = plt.hist(x, bins=30, density=True)"
    ]
   },
   {
@@ -228,7 +228,7 @@
     "                                   'ylim':(-0.02, 0.3)})\n",
     "fig.subplots_adjust(wspace=0.05)\n",
     "for i, offset in enumerate([0.0, 0.6]):\n",
-    "    ax[i].hist(x, bins=bins + offset, normed=True)\n",
+    "    ax[i].hist(x, bins=bins + offset, density=True)\n",
     "    ax[i].plot(x, np.full_like(x, -0.01), '|k',\n",
     "               markeredgewidth=1)"
    ]


### PR DESCRIPTION
`matplotlib.pyplot.hist`'s `normed` parameter is deprecated and will be removed.

This PR changes deprecated `normed` parameter to `density`.