### PR TITLE
0.4.05 Fix tessellation typo

### DIFF
--- a/notebooks/04.05-Histograms-and-Binnings.ipynb
+++ b/notebooks/04.05-Histograms-and-Binnings.ipynb
@@ -261,8 +261,8 @@
    "source": [
     "### ``plt.hexbin``: Hexagonal binnings\n",
     "\n",
-    "The two-dimensional histogram creates a tesselation of squares across the axes.\n",
-    "Another natural shape for such a tesselation is the regular hexagon.\n",
+    "The two-dimensional histogram creates a tessellation of squares across the axes.\n",
+    "Another natural shape for such a tessellation is the regular hexagon.\n",
     "For this purpose, Matplotlib provides the ``plt.hexbin`` routine, which will represents a two-dimensional dataset binned within a grid of hexagons:"
    ]
   },


### PR DESCRIPTION
This PR fix the following typo:

`tesselation` -> `tessellation`