### PR TITLE
add inline code span for and/or &/| operators

### DIFF
--- a/notebooks/02.06-Boolean-Arrays-and-Masks.ipynb
+++ b/notebooks/02.06-Boolean-Arrays-and-Masks.ipynb
@@ -944,7 +944,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Aside: Using the Keywords and/or Versus the Operators &/|\n",
+    "## Aside: Using the Keywords ``and``/``or`` Versus the Operators ``&``/``|``\n",
     "\n",
     "One common point of confusion is the difference between the keywords ``and`` and ``or`` on one hand, and the operators ``&`` and ``|`` on the other hand.\n",
     "When would you use one versus the other?\n",


### PR DESCRIPTION
This PR changes:

- and/or -> `and`/`or`
- &/| ->  `&`/`|`