### PR TITLE
Update 02.09-Structured-Data-NumPy.ipynb

### DIFF
--- a/notebooks/02.09-Structured-Data-NumPy.ipynb
+++ b/notebooks/02.09-Structured-Data-NumPy.ipynb
@@ -404,7 +404,7 @@
     "| ``'b'``          | Byte                  | ``np.dtype('b')``                   |\n",
     "| ``'i'``          | Signed integer        | ``np.dtype('i4') == np.int32``      |\n",
     "| ``'u'``          | Unsigned integer      | ``np.dtype('u1') == np.uint8``      |\n",
-    "| ``'f'``          | Floating point        | ``np.dtype('f8') == np.int64``      |\n",
+    "| ``'f'``          | Floating point        | ``np.dtype('f8') == np.float64``      |\n",
     "| ``'c'``          | Complex floating point| ``np.dtype('c16') == np.complex128``|\n",
     "| ``'S'``, ``'a'`` | String                | ``np.dtype('S5')``                  |\n",
     "| ``'U'``          | Unicode string        | ``np.dtype('U') == np.str_``        |\n",


### PR DESCRIPTION
The table mentioning different data types and their shorthand encodings has a typo for floating point.
``np.dtype('f8') == np.float64`` [instead of ``np.int64``]