### PR TITLE
Fixing errors when running histogram customization on 04.11-Settings-and-Stylesheets.ipynb

### DIFF
--- a/notebooks/04.11-Settings-and-Stylesheets.ipynb
+++ b/notebooks/04.11-Settings-and-Stylesheets.ipynb
@@ -108,14 +108,15 @@
       "text/plain": [
        "<matplotlib.figure.Figure at 0x10c2bea20>"
       ]
-     },
+     },http://localhost:8888/tree?token=577d00d538a1ea552f21cc8f03246cc241c6bbfdf4dd3320
      "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
     "# use a gray background\n",
-    "ax = plt.axes(axisbg='#E6E6E6')\n",
+    "ax = plt.axes()\n",
+    "ax.set_facecolor('#E6E6E6')",
     "ax.set_axisbelow(True)\n",
     "\n",
     "# draw solid white grid lines\n",
@@ -126,8 +127,8 @@
     "    spine.set_visible(False)\n",
     "    \n",
     "# hide top and right ticks\n",
-    "ax.xaxis.tick_bottom()\n",
-    "ax.yaxis.tick_left()\n",
+    "ax.tick_params(top=False)\n",
+    "ax.tick_params(right=False)\n",
     "\n",
     "# lighten ticks and labels\n",
     "ax.tick_params(colors='gray', direction='out')\n",


### PR DESCRIPTION
I believe the code has stopped working due to Matplotlib´s version updates. it gives an error when setting the graph´s background and also when hiding top and right ticks.

So, this pull request is:
- Fixing the graph background color and axes ticks by creating an `axes` object and then setting it´s `set_facecolor` to gray. 
- Hiding top and right ticks with `ax.tick_params`.

The code diffs are:
1.  `ax = plt.axes(axisbg='#E6E6E6')`  to 
`ax = plt.axes( )
ax.set_facecolor('#E6E6E6')`

2. `ax.xaxis.tick_bottom() ax.yaxis.tick_left()` to
`ax.tick_params(top=False) ax.tick_params(right=False)`