### PR TITLE
Update 05.09-Principal-Component-Analysis.ipynb

### DIFF
--- a/notebooks/05.09-Principal-Component-Analysis.ipynb
+++ b/notebooks/05.09-Principal-Component-Analysis.ipynb
@@ -486,7 +486,7 @@
    "source": [
     "plt.scatter(projected[:, 0], projected[:, 1],\n",
     "            c=digits.target, edgecolor='none', alpha=0.5,\n",
-    "            cmap=plt.cm.get_cmap('spectral', 10))\n",
+    "            cmap=plt.cm.get_cmap('rainbow', 10))\n",
     "plt.xlabel('component 1')\n",
     "plt.ylabel('component 2')\n",
     "plt.colorbar();"


### PR DESCRIPTION
Running block 11 returns an error message when the colormap is set to `spectral` (see below).  This PR replaces the colormap to `rainbow`.

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-23-6d6d01ae596c> in <module>
      1 plt.scatter(projected[:, 0], projected[:, 1],
      2             c=digits.target, edgecolor='none', alpha=0.5,
----> 3             cmap=plt.cm.get_cmap('spectral', 10))
      4 plt.xlabel('component 1')
      5 plt.ylabel('component 2')

~/opt/anaconda3/lib/python3.7/site-packages/matplotlib/cm.py in get_cmap(name, lut)
    132     if isinstance(name, colors.Colormap):
    133         return name
--> 134     cbook._check_in_list(sorted(cmap_d), name=name)
    135     if lut is None:
    136         return cmap_d[name]

~/opt/anaconda3/lib/python3.7/site-packages/matplotlib/cbook/__init__.py in _check_in_list(_values, **kwargs)
   2143             raise ValueError(
   2144                 "{!r} is not a valid value for {}; supported values are {}"
-> 2145                 .format(v, k, ', '.join(map(repr, values))))
   2146 
   2147 

ValueError: 'spectral' is not a valid value for name; supported values are 'Accent', 'Accent_r', 'Blues', 'Blues_r', 'BrBG', 'BrBG_r', 'BuGn', 'BuGn_r', 'BuPu', 'BuPu_r', 'CMRmap', 'CMRmap_r', 'Dark2', 'Dark2_r', 'GnBu', 'GnBu_r', 'Greens', 'Greens_r', 'Greys', 'Greys_r', 'OrRd', 'OrRd_r', 'Oranges', 'Oranges_r', 'PRGn', 'PRGn_r', 'Paired', 'Paired_r', 'Pastel1', 'Pastel1_r', 'Pastel2', 'Pastel2_r', 'PiYG', 'PiYG_r', 'PuBu', 'PuBuGn', 'PuBuGn_r', 'PuBu_r', 'PuOr', 'PuOr_r', 'PuRd', 'PuRd_r', 'Purples', 'Purples_r', 'RdBu', 'RdBu_r', 'RdGy', 'RdGy_r', 'RdPu', 'RdPu_r', 'RdYlBu', 'RdYlBu_r', 'RdYlGn', 'RdYlGn_r', 'Reds', 'Reds_r', 'Set1', 'Set1_r', 'Set2', 'Set2_r', 'Set3', 'Set3_r', 'Spectral', 'Spectral_r', 'Wistia', 'Wistia_r', 'YlGn', 'YlGnBu', 'YlGnBu_r', 'YlGn_r', 'YlOrBr', 'YlOrBr_r', 'YlOrRd', 'YlOrRd_r', 'afmhot', 'afmhot_r', 'autumn', 'autumn_r', 'binary', 'binary_r', 'bone', 'bone_r', 'brg', 'brg_r', 'bwr', 'bwr_r', 'cividis', 'cividis_r', 'cool', 'cool_r', 'coolwarm', 'coolwarm_r', 'copper', 'copper_r', 'crest', 'crest_r', 'cubehelix', 'cubehelix_r', 'flag', 'flag_r', 'flare', 'flare_r', 'gist_earth', 'gist_earth_r', 'gist_gray', 'gist_gray_r', 'gist_heat', 'gist_heat_r', 'gist_ncar', 'gist_ncar_r', 'gist_rainbow', 'gist_rainbow_r', 'gist_stern', 'gist_stern_r', 'gist_yarg', 'gist_yarg_r', 'gnuplot', 'gnuplot2', 'gnuplot2_r', 'gnuplot_r', 'gray', 'gray_r', 'hot', 'hot_r', 'hsv', 'hsv_r', 'icefire', 'icefire_r', 'inferno', 'inferno_r', 'jet', 'jet_r', 'magma', 'magma_r', 'mako', 'mako_r', 'nipy_spectral', 'nipy_spectral_r', 'ocean', 'ocean_r', 'pink', 'pink_r', 'plasma', 'plasma_r', 'prism', 'prism_r', 'rainbow', 'rainbow_r', 'rocket', 'rocket_r', 'seismic', 'seismic_r', 'spring', 'spring_r', 'summer', 'summer_r', 'tab10', 'tab10_r', 'tab20', 'tab20_r', 'tab20b', 'tab20b_r', 'tab20c', 'tab20c_r', 'terrain', 'terrain_r', 'twilight', 'twilight_r', 'twilight_shifted', 'twilight_shifted_r', 'viridis', 'viridis_r', 'vlag', 'vlag_r', 'winter', 'winter_r'
```