### PR TITLE
Gaussianmixture

### DIFF
--- a/notebooks/05.12-Gaussian-Mixtures.ipynb
+++ b/notebooks/05.12-Gaussian-Mixtures.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "# Generate some data\n",
-    "from sklearn.datasets.samples_generator import make_blobs\n",
+    "from sklearn.datasets import make_blobs\n",
     "X, y_true = make_blobs(n_samples=400, centers=4,\n",
     "                       cluster_std=0.60, random_state=0)\n",
     "X = X[:, ::-1] # flip axes for better plotting"

--- a/notebooks/05.12-Gaussian-Mixtures.ipynb
+++ b/notebooks/05.12-Gaussian-Mixtures.ipynb
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "from sklearn.mixture import GMM\n",
+    "from sklearn.mixture import GaussianMixture as GMM\n",
     "gmm = GMM(n_components=4).fit(X)\n",
     "labels = gmm.predict(X)\n",
     "plt.scatter(X[:, 0], X[:, 1], c=labels, s=40, cmap='viridis');"
@@ -427,7 +427,7 @@
     "    ax.axis('equal')\n",
     "    \n",
     "    w_factor = 0.2 / gmm.weights_.max()\n",
-    "    for pos, covar, w in zip(gmm.means_, gmm.covars_, gmm.weights_):\n",
+    "    for pos, covar, w in zip(gmm.means_, gmm.covariances_, gmm.weights_):\n",
     "        draw_ellipse(pos, covar, alpha=w * w_factor)"
    ]
   },
@@ -684,7 +684,8 @@
     }
    ],
    "source": [
-    "Xnew = gmm16.sample(400, random_state=42)\n",
+    "gmm16.random_state = 42\n",
+    "Xnew = gmm16.sample(400)[0]\n",
     "plt.scatter(Xnew[:, 0], Xnew[:, 1]);"
    ]
   },
@@ -985,7 +986,7 @@
     }
    ],
    "source": [
-    "data_new = gmm.sample(100, random_state=0)\n",
+    "data_new = gmm.sample(100)[0]\n",
     "data_new.shape"
    ]
   },
@@ -1067,7 +1068,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.8.5-final"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This allows notebook to run on scikit-learn 0.18+. The calling convention has changed since that release, with name `GaussianMixture` instead of old `GMM`. Parameter `covariances_` instead of `covars_`, `random_state` can only be assigned to model, not the sample, and `sample` now returns a tuple of which the 0th element is the desired array of samples. Also fixed a deprecation warning about `make_blobs` which is now to be imported directly from `sklearn.datasets` instead of deprecated `samples_generator`. I've tested this on my Anaconda install (Python-3.8.5, scikit-learn-0.23.2) and on colab. (Thanks for producing this fantastic book and this demo!)