### PR TITLE
subtle typo

### DIFF
--- a/notebooks/01.04-Input-Output-History.ipynb
+++ b/notebooks/01.04-Input-Output-History.ipynb
@@ -157,7 +157,7 @@
     "In [14]: math.sin(2) + math.cos(2);\n",
     "```\n",
     "\n",
-    "Note that the result is computed silently, and the output is neither displayed on the screen or stored in the ``Out`` dictionary:\n",
+    "Note that the result is computed silently, and the output is neither displayed on the screen nor stored in the ``Out`` dictionary:\n",
     "\n",
     "```ipython\n",
     "In [15]: 14 in Out\n",


### PR DESCRIPTION
I know that this is a bit controversial and using "neither" with "or" is grammatically correct. however it's better to use "neither" with "nor".