### PR TITLE
Updated a link

### DIFF
--- a/notebooks/01.08-More-IPython-Resources.ipynb
+++ b/notebooks/01.08-More-IPython-Resources.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "- [The IPython website](http://ipython.org): The IPython website links to documentation, examples, tutorials, and a variety of other resources.\n",
     "- [The nbviewer website](http://nbviewer.jupyter.org/): This site shows static renderings of any IPython notebook available on the internet. The front page features some example notebooks that you can browse to see what other folks are using IPython for!\n",
-    "- [A gallery of interesting Jupyter Notebooks](https://github.com/jupyter/jupyter/wiki/A-gallery-of-interesting-Jupyter-Notebooks/): This ever-growing list of notebooks, powered by nbviewer, shows the depth and breadth of numerical analysis you can do with IPython. It includes everything from short examples and tutorials to full-blown courses and books composed in the notebook format!\n",
+    "- [A gallery of interesting Jupyter Notebooks](https://github.com/jupyter/jupyter/wiki#a-gallery-of-interesting-jupyter-notebooks/): This ever-growing list of notebooks, powered by nbviewer, shows the depth and breadth of numerical analysis you can do with IPython. It includes everything from short examples and tutorials to full-blown courses and books composed in the notebook format!\n",
     "- Video Tutorials: searching the Internet, you will find many video-recorded tutorials on IPython. I'd especially recommend seeking tutorials from the PyCon, SciPy, and PyData conferenes by Fernando Perez and Brian Granger, two of the primary creators and maintainers of IPython and Jupyter."
    ]
   },


### PR DESCRIPTION
Updated the link to "A gallery of interesting Jupyter Notebooks"
Previously it is https://github.com/jupyter/jupyter/wiki/A-gallery-of-interesting-Jupyter-Notebooks/
Current working link: https://github.com/jupyter/jupyter/wiki#a-gallery-of-interesting-jupyter-notebooks/

This fixes the issue [01.08 link changed #331](https://github.com/jakevdp/PythonDataScienceHandbook/issues/331)