### PR TITLE
Update 03.05-Hierarchical-Indexing.ipynb

### DIFF
--- a/notebooks_v1/03.05-Hierarchical-Indexing.ipynb
+++ b/notebooks_v1/03.05-Hierarchical-Indexing.ipynb
@@ -911,7 +911,7 @@
      "data": {
       "text/plain": [
        "MultiIndex(levels=[['a', 'b'], [1, 2]],\n",
-       "           labels=[[0, 0, 1, 1], [0, 1, 0, 1]])"
+       "           codes=[[0, 0, 1, 1], [0, 1, 0, 1]])"
       ]
      },
      "execution_count": 17,


### PR DESCRIPTION
I think I discovered a small bug when running cell 17. The MultiIndex constructor takes "codes" not "labels" as its input when doing the internal encoding. Tested on pandas 2.2.2. 

The original error was: TypeError: __new__() got an unexpected keyword argument 'labels'